### PR TITLE
Iscitable

### DIFF
--- a/app/application.py
+++ b/app/application.py
@@ -113,7 +113,7 @@ def cite(software_id):
     if "error" in software_dictionary:
         return flask.redirect("/", code=302)
 
-    releases = software_dictionary['releases']['releases']
+    releases = software_dictionary['releases']
 
     for release in releases:
         if release['tag'] == flask.request.args.get('version'):

--- a/templates/software/citation.html
+++ b/templates/software/citation.html
@@ -1,12 +1,12 @@
 <!-- Cite this software -->
-{% if template_data.isCitable and template_data.conceptDOI %}
+{% if template_data.isCitable %}
 <section id="cite-this">
     <div class="container">
         <div class="row bg-dark citation-block" :style="releases && 'min-height: 16em'">
 
             <div class="col-1-3">
                 <h2 class="subtitle">Cite this software</h2>
-                {% if template_data.releases.releases %}
+                {% if template_data.releases %}
                 <div class="citation-block_version">
                      <h5>Choose a version:</h5>
                      <div class="row">
@@ -82,13 +82,13 @@
             delimiters: ["[[", "]]"],
             data: {
                 conceptDOI: {{ template_data.conceptDOI | tojson | safe }},
-                releases: {{ template_data.releases.releases | sort(attribute='datePublished', reverse=True) | releases_filter | tojson | safe }},
+                releases: {{ template_data.releases | sort(attribute='datePublished', reverse=True) | releases_filter | tojson | safe }},
                 selectedIndex: 0,
                 versionDropdownOpen: false,
                 fileFormatDropdownOpen: false,
                 fileFormats: [
                     { extension: 'bibtex', name: 'BibTeX' },
-                    { extension: 'endnote', name: 'Endnote' },
+                    { extension: 'endnote', name: 'EndNote' },
                     { extension: 'ris', name: 'RIS' }
                 ],
                 selectedFileFormatIndex: 0


### PR DESCRIPTION
With this PR, the site includes a citation block with more or less data, depending on what sort of information has been derived. Anywhere from just a doi and nothing else to a list of per-version dois with buttons to download to various reference managers. At the time of creation, the only items that don't show a citation block are those with 10.0000/FIXME dois, which is how it should be.

counterpart to this PR is https://github.com/research-software-directory/tasks-nlesc/pull/4

looks like the failing checks should be resolved once the new ``releases`` task and ``cache_software`` have run 