### PR TITLE
No mentions from the future

### DIFF
--- a/app/application.py
+++ b/app/application.py
@@ -49,10 +49,10 @@ def get_mentions(software_list):
     # 3. sort the list by date
     # 4. use slicing in index_template.html to display the top N items
 
-    now = datetime.strftime(datetime.utcnow(), '%Y-%m-%dT%H:%M:%SZ')
     if software_list is None:
         return []
     else:
+        now = datetime.strftime(datetime.utcnow(), '%Y-%m-%dT%H:%M:%SZ')
         mentions = dict()
         for software in software_list:
             for mention in software['related']['mentions']:

--- a/templates/index_template.html
+++ b/templates/index_template.html
@@ -236,7 +236,7 @@
     
         <div class="col-2-3">
           <ul>
-            {% for mention in mentions[:5]  %}
+            {% for mention in mentions[:7] %}
             <li>
 
                 {% if mention.url %}


### PR DESCRIPTION
The index page used to have mentions with dates in the future; this PR corrects that by simply hiding mentions with dates that are greater than now; Also I took the opportunity to refactor the ``get_mentions()`` function a bit, because I found it difficult to read.